### PR TITLE
Update name of new characteristic to avoid same name as LED

### DIFF
--- a/NiclaMagnetCentral/NiclaMagnetCentral.ino
+++ b/NiclaMagnetCentral/NiclaMagnetCentral.ino
@@ -213,7 +213,7 @@ void exploreCharacteristic(BLECharacteristic characteristic) {
         Serial.print(" Gas: ");
         Serial.print(gas);
       }
-      if (characteristic.uuid() == String("19b10000-9001-537e-4f6c-d104768a1214")) {
+      if (characteristic.uuid() == String("107d")) {
         uint16_t state = 0;
         BLECharateristic_to_value(characteristic, &state);
         myNiclaAPI.data.severityLevel = (warning_levels)state;

--- a/NiclaSensePeripheral/NiclaSensePeripheral.ino
+++ b/NiclaSensePeripheral/NiclaSensePeripheral.ino
@@ -37,7 +37,9 @@ enum state { NORMAL,
 #define BLE_UUID_CARBON_DIOXIDE_SENSOR "054A"
 #define BLE_UUID_AIR_QUALITY_SENSOR "0542"
 #define BLE_UUID_GAS_SENSOR "107A"
+#define BLE_UUID_STATTE "107D"
 #define BLE_UUID_VERSION "2A28"
+
 
 #define BLE_SENSE_UUID(val) ("19b10000-" val "-537e-4f6c-d104768a1214")
 
@@ -77,7 +79,7 @@ BLEIntCharacteristic co2Characteristic(BLE_UUID_CARBON_DIOXIDE_SENSOR, BLERead);
 BLEUnsignedIntCharacteristic gasCharacteristic(BLE_UUID_GAS_SENSOR, BLERead);
 
 BLECharacteristic rgbLedCharacteristic(BLE_SENSE_UUID("8001"), BLERead | BLEWrite, 3 * sizeof(byte));  // Array of 3 bytes, RGB
-BLEUnsignedIntCharacteristic stateCharacteristic(BLE_SENSE_UUID("9001"), BLERead);
+BLEUnsignedIntCharacteristic stateCharacteristic(BLE_UUID_STATTE, BLERead);
 
 // String to calculate the local and device name
 String name;


### PR DESCRIPTION
I noticed that the name of the new characteristic reporting the state was also appearing under another characteristic with the same ID, so I updated it to a new number on both sides. It is just for consistency with the other characteristics 